### PR TITLE
add preVerifycationGas for UserOperation

### DIFF
--- a/contracts/gasless/interfaces/UserOperartion.sol
+++ b/contracts/gasless/interfaces/UserOperartion.sol
@@ -18,6 +18,7 @@ struct UserOperation {
     bytes callData;
     uint256 callGasLimit;
     uint256 verificationGasLimit;
+    uint256 preVerificationGas;
     uint256 maxFeePerGas;
     uint256 maxPriorityFeePerGas;
     bytes paymasterAndData;

--- a/test/demo-paymaster.ts
+++ b/test/demo-paymaster.ts
@@ -88,6 +88,7 @@ describe("EntryPoint with whitelist paymaster", function () {
         callData: dummyContractCallData,
         callGasLimit: 100000,
         verificationGasLimit: 100000,
+        preVerificationGas: 60000,
         maxFeePerGas: 1,
         maxPriorityFeePerGas: 1,
         paymasterAndData: hexConcat([alwaysSuccessPaymaster.address, "0x1234"]),
@@ -113,6 +114,7 @@ describe("EntryPoint with whitelist paymaster", function () {
         callData: dummyContractCallData,
         callGasLimit: 100000,
         verificationGasLimit: 100000,
+        preVerificationGas: 60000,
         maxFeePerGas: 1,
         maxPriorityFeePerGas: 1,
         paymasterAndData: hexConcat([paymaster.address, "0x1234"]),
@@ -141,6 +143,7 @@ describe("EntryPoint with whitelist paymaster", function () {
         callData: dummyContractCallData,
         callGasLimit: 100000,
         verificationGasLimit: 100000,
+        preVerificationGas: 60000,
         maxFeePerGas: 1,
         maxPriorityFeePerGas: 1,
         paymasterAndData: hexConcat([paymaster.address, "0x1234"]),
@@ -168,6 +171,7 @@ describe("EntryPoint with whitelist paymaster", function () {
         callData: dummyContractCallData,
         callGasLimit: 100000,
         verificationGasLimit: 100000,
+        preVerificationGas: 60000,
         maxFeePerGas: 1,
         maxPriorityFeePerGas: 1,
         paymasterAndData: hexConcat([paymaster.address, "0x1234"]),
@@ -181,11 +185,11 @@ describe("EntryPoint with whitelist paymaster", function () {
       const abiCoder = new ethers.utils.AbiCoder();
       let payload = abiCoder.encode(
         [
-          "tuple(address callContract, bytes callData, uint256 callGasLimit, uint256 verificationGasLimit, uint256 maxFeePerGas, uint256 maxPriorityFeePerGas, bytes paymasterAndData) UserOperation",
+          "tuple(address callContract, bytes callData, uint256 callGasLimit, uint256 verificationGasLimit, uint256 preVerificationGas, uint256 maxFeePerGas, uint256 maxPriorityFeePerGas, bytes paymasterAndData) UserOperation",
         ],
         [userOp]
       );
-      payload = "0xfb4350d8" + payload.slice(2);
+      payload = "0xb4e9984f" + payload.slice(2);
 
       const plainTx = {
         from: whitelistUser.address,
@@ -212,6 +216,7 @@ describe("EntryPoint with whitelist paymaster", function () {
         callData: dummyContractCallData,
         callGasLimit: 100000,
         verificationGasLimit: 100000,
+        preVerificationGas: 60000,
         maxFeePerGas: 1,
         maxPriorityFeePerGas: 1,
         paymasterAndData: hexConcat([paymaster.address, "0x1234"]),
@@ -235,6 +240,7 @@ describe("EntryPoint with whitelist paymaster", function () {
         callData: dummyContractCallData,
         callGasLimit: 100000,
         verificationGasLimit: 100000,
+        preVerificationGas: 60000,
         maxFeePerGas: 1,
         maxPriorityFeePerGas: 1,
         paymasterAndData: hexConcat([paymaster.address, "0x1234"]),
@@ -296,6 +302,7 @@ describe("EntryPoint with whitelist paymaster", function () {
           callData,
           callGasLimit: 100000,
           verificationGasLimit: 100000,
+          preVerificationGas: 60000,
           maxFeePerGas: 1,
           maxPriorityFeePerGas: 1,
           paymasterAndData: hexConcat([paymaster.address, "0x1234"]),

--- a/test/entrypoint.ts
+++ b/test/entrypoint.ts
@@ -1,0 +1,94 @@
+import { BigNumber, Contract, ContractFactory, Wallet } from "ethers";
+import { ethers, network } from "hardhat";
+import {
+  EntryPoint,
+  DemoPaymaster,
+  DummyContract,
+  AlwaysSuccessPaymaster__factory,
+} from "../typechain-types";
+import { hexConcat, parseEther } from "ethers/lib/utils";
+import { UserOperationStruct } from "../typechain-types/contracts/gasless/core/EntryPoint";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import "@nomicfoundation/hardhat-chai-matchers";
+import { createNonRandomWallet, getOrDeployEntrypointContract } from "./util";
+
+describe("EntryPoint with whitelist paymaster", function () {
+  let dummyContractCallData: string;
+  let walletOwner: SignerWithAddress;
+  let whitelistUser: SignerWithAddress;
+  const invalidUser: Wallet = createNonRandomWallet();
+  let dummyContract: DummyContract;
+  let entryPoint: EntryPoint;
+  let alwaysSuccessPaymaster: DemoPaymaster;
+
+  const fullnode: Wallet = createNonRandomWallet();
+  const depositAmount = parseEther("0.01");
+
+  beforeEach(async function () {
+    const [_walletOwner, _whitelistUser] = await ethers.getSigners();
+    walletOwner = _walletOwner;
+    whitelistUser = _whitelistUser;
+    const DummyContract = await ethers.getContractFactory("DummyContract");
+    dummyContract = await DummyContract.deploy();
+    console.log(`Deploy dummy contract: ${dummyContract.address}`);
+    const testTx = await dummyContract.populateTransaction.test(1, 1);
+    dummyContractCallData = testTx.data ?? "";
+
+    entryPoint = await getOrDeployEntrypointContract(fullnode.address, 1, 1);
+    // const entryPointAddr = "0xd16f6ec881e60038596c193b534c840455e66f47"
+    // const entryPoint = EntryPoint__factory.connect(entryPointAddr, walletOwner)
+    // 0xd16f6ec881e60038596c193b534c840455e66f47
+    console.log(`Deploy EntryPoint contract: ${entryPoint.address}`);
+    console.log(`wallet owner: ${walletOwner.address}`);
+    console.log(`User in whitelist: ${whitelistUser.address}`);
+
+    alwaysSuccessPaymaster = await new AlwaysSuccessPaymaster__factory(
+        walletOwner
+      ).deploy(entryPoint.address);
+      console.log(
+        `Always Success Paymaster: ${alwaysSuccessPaymaster.address}`
+      );
+      await alwaysSuccessPaymaster.addStake(99999999, {
+        value: parseEther("1.02"),
+      });
+      console.log("add stake for alwaysSuccessPaymaster");
+      await entryPoint.depositTo(alwaysSuccessPaymaster.address, {
+        value: depositAmount,
+      });
+      console.log("deposit to entrypoint for always success paymaster");
+  });
+  describe("#Entrypoint", () => {
+    it("should cover cost", async () => {
+      // Mock UserOp
+      const userOp: UserOperationStruct = {
+        callContract: dummyContract.address,
+        callData: dummyContractCallData,
+        callGasLimit: 100000,
+        verificationGasLimit: 100000,
+        maxFeePerGas: 1,
+        maxPriorityFeePerGas: 1,
+        paymasterAndData: hexConcat([alwaysSuccessPaymaster.address, "0x1234"]),
+      };
+
+      // init state
+      const initSum = await dummyContract.sum();
+      expect(initSum).to.equal(1);
+      const initDeposit = await entryPoint.balanceOf(alwaysSuccessPaymaster.address);
+      expect(initDeposit).to.equal(depositAmount);
+
+      // Send tx with a valid user.
+      const tx = await entryPoint
+        .connect(invalidUser)
+        .handleOp(userOp, { gasLimit: 400000, gasPrice: 0 });
+      const receipt = await tx.wait();
+      expect(receipt.status).equal(1);
+      // check state changed
+      const sum = await dummyContract.sum();
+      expect(sum).to.equal(2);
+
+      const deposit = await entryPoint.balanceOf(alwaysSuccessPaymaster.address);
+      expect(receipt.gasUsed.mul(userOp.maxFeePerGas as string)).to.equal(initDeposit.sub(deposit));
+    });
+  });
+});

--- a/test/entrypoint.ts
+++ b/test/entrypoint.ts
@@ -1,5 +1,5 @@
-import { BigNumber, Contract, ContractFactory, Wallet } from "ethers";
-import { ethers, network } from "hardhat";
+import { Wallet } from "ethers";
+import { ethers } from "hardhat";
 import {
   EntryPoint,
   DemoPaymaster,
@@ -44,37 +44,60 @@ describe("EntryPoint with whitelist paymaster", function () {
     console.log(`User in whitelist: ${whitelistUser.address}`);
 
     alwaysSuccessPaymaster = await new AlwaysSuccessPaymaster__factory(
-        walletOwner
-      ).deploy(entryPoint.address);
-      console.log(
-        `Always Success Paymaster: ${alwaysSuccessPaymaster.address}`
-      );
-      await alwaysSuccessPaymaster.addStake(99999999, {
-        value: parseEther("1.02"),
-      });
-      console.log("add stake for alwaysSuccessPaymaster");
-      await entryPoint.depositTo(alwaysSuccessPaymaster.address, {
-        value: depositAmount,
-      });
-      console.log("deposit to entrypoint for always success paymaster");
+      walletOwner
+    ).deploy(entryPoint.address);
+    console.log(`Always Success Paymaster: ${alwaysSuccessPaymaster.address}`);
+    await alwaysSuccessPaymaster.addStake(99999999, {
+      value: parseEther("1.02"),
+    });
+    console.log("add stake for alwaysSuccessPaymaster");
+    await entryPoint.depositTo(alwaysSuccessPaymaster.address, {
+      value: depositAmount,
+    });
+    console.log("deposit to entrypoint for always success paymaster");
   });
   describe("#Entrypoint", () => {
     it("should cover cost", async () => {
-      // Mock UserOp
-      const userOp: UserOperationStruct = {
+      const zeroAddr = "0x" + "00".repeat(20);
+
+      const baseUserOp: UserOperationStruct = {
         callContract: dummyContract.address,
         callData: dummyContractCallData,
         callGasLimit: 100000,
         verificationGasLimit: 100000,
         maxFeePerGas: 1,
         maxPriorityFeePerGas: 1,
+        preVerificationGas: 100000,
         paymasterAndData: hexConcat([alwaysSuccessPaymaster.address, "0x1234"]),
       };
+
+      const callGasLimit = await entryPoint
+        .connect(zeroAddr)
+        .callStatic.simulateCallContract(baseUserOp);
+      baseUserOp.callGasLimit = callGasLimit;
+
+      const { preOpGas } = await entryPoint
+        .connect(zeroAddr)
+        .callStatic.simulateValidation(baseUserOp, { gasPrice: 0 });
+      const verificationGasLimit = preOpGas.mul(1);
+
+      baseUserOp.verificationGasLimit = verificationGasLimit;
+      const total = await entryPoint.estimateGas.handleOp(baseUserOp, {
+        gasPrice: 0,
+      });
+      baseUserOp.preVerificationGas = total
+        .sub(callGasLimit)
+        .sub(verificationGasLimit);
+
+      // Mock UserOp
+      const userOp: UserOperationStruct = baseUserOp;
 
       // init state
       const initSum = await dummyContract.sum();
       expect(initSum).to.equal(1);
-      const initDeposit = await entryPoint.balanceOf(alwaysSuccessPaymaster.address);
+      const initDeposit = await entryPoint.balanceOf(
+        alwaysSuccessPaymaster.address
+      );
       expect(initDeposit).to.equal(depositAmount);
 
       // Send tx with a valid user.
@@ -87,8 +110,15 @@ describe("EntryPoint with whitelist paymaster", function () {
       const sum = await dummyContract.sum();
       expect(sum).to.equal(2);
 
-      const deposit = await entryPoint.balanceOf(alwaysSuccessPaymaster.address);
-      expect(receipt.gasUsed.mul(userOp.maxFeePerGas as string)).to.equal(initDeposit.sub(deposit));
+      const deposit = await entryPoint.balanceOf(
+        alwaysSuccessPaymaster.address
+      );
+      // todo: it seems hard to make the gas cost equals to the real income on boundler
+      // we only check if the income is larger than the real cost
+      // in another word, we charge more.
+      expect(receipt.gasUsed.mul(userOp.maxFeePerGas as string)).to.lt(
+        initDeposit.sub(deposit)
+      );
     });
   });
 });


### PR DESCRIPTION
in order to solve the problem that the charge of the gasless transaction is not equal to the real gas cost, we add the `preVerifycationGas` back to `UserOperation` struct

notes:

- `handleOp` fn signature changed due to UserOperation structure changed. need to adapt for web and gw.
- the gas limit check should update to include the `preVerifycationGas` in web3.
- web3 must also check if the `preVerifycationGas` can cover the gas cost gap before submit the tx.
- the real cost is hard to cover equally, in the current work-flow(simulateValidation and simulateCallContract to get what gas of each part should be ) we end up charging a little more than the real gas cost.